### PR TITLE
Add pointer hover to Standard Button component

### DIFF
--- a/simplq/src/components/common/Button/button.module.scss
+++ b/simplq/src/components/common/Button/button.module.scss
@@ -23,6 +23,7 @@
 
   &:hover {
     background: #4e4c66 radial-gradient(circle, transparent 1%, #4e4c66 1%) center/15000%;
+    cursor: pointer;
   }
 
   &:active {


### PR DESCRIPTION
closes #450

Mouse icon changed from default to pointer for Standard button component.
I have changed the Standard button sass file (button.module.sass) to show a pointer cursor on hover. 
```diff
&:hover {
background: #4e4c66 radial-gradient(circle, transparent 1%, #4e4c66 1%) center/15000%;
+cursor:pointer    
 }
```
This change was done so that the user experience would be improved and the user can identify that the component is clickable.

Please let me know if I need to add some more changes to my pull request if necessary. This is my first time contributing to this repo.  

Thanks, 

